### PR TITLE
remove helm.sh/hook: pre-install

### DIFF
--- a/charts/kasm/templates/kasm-password-secret.yaml
+++ b/charts/kasm/templates/kasm-password-secret.yaml
@@ -19,7 +19,6 @@ metadata:
     {{- with .Values.extraLabels.secret }}{{- toYaml . | nindent 4 }}{{- end }}
     {{- with .Values.labels }}{{- toYaml . | nindent 4 }}{{- end }}
   annotations:
-    helm.sh/hook: pre-install
     {{- with .Values.annotations.secret }}{{- toYaml . | nindent 4 }}{{- end }}
 type: Opaque
 data:


### PR DESCRIPTION
Having this hook reinitializes the secrets every time the chart is reapplied. This causes issues with CD/CI automated deployment pipelines.

If a simple update is made we shouldn't be reinitializing this as the system then loses access to the database.