### PR TITLE
fix: separate db-init-job annotations to prevent ArgoCD deadlock

### DIFF
--- a/charts/kasm/Chart.yaml
+++ b/charts/kasm/Chart.yaml
@@ -28,4 +28,4 @@ keywords:
 maintainers:
   - name: Kasm Technologies, Inc.
     url: https://github.com/kasmtech/kasm-helm
-version: 1.1181.0
+version: 1.1181.1

--- a/charts/kasm/templates/db-init-job.yaml
+++ b/charts/kasm/templates/db-init-job.yaml
@@ -11,12 +11,11 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}-db-init
     {{- include "kasm.defaultLabels" . | indent 4 }}
-    {{- with .Values.components.api.labels }}{{- toYaml . | nindent 4 }}{{- end }}
+    {{- with .Values.components.init_db.labels }}{{- toYaml . | nindent 4 }}{{- end }}
     {{- with .Values.extraLabels.job }}{{- toYaml . | nindent 4 }}{{- end }}
     {{- with .Values.labels }}{{- toYaml . | nindent 4 }}{{- end }}
-  {{- with .Values.components.api.annotations }}
+  {{- with .Values.components.init_db.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
-    helm.sh/hook: pre-install
   {{- end }}
 spec:
   ttlSecondsAfterFinished: 100
@@ -26,13 +25,13 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-db-init
         app.kubernetes.io/component: db-init
         {{- include "kasm.defaultLabels" . | indent 8 }}
-        {{- with .Values.components.api.labels }}{{ toYaml . | nindent 8 }}{{- end }}
+        {{- with .Values.components.init_db.labels }}{{ toYaml . | nindent 8 }}{{- end }}
         {{- with .Values.extraLabels.jobPod }}{{ toYaml . | nindent 8 }}{{- end }}
         {{- with .Values.labels }}{{- toYaml . | nindent 8 }}{{- end }}
-      {{- if or .Values.components.api.annotations .Values.annotations.pod }}
+      {{- if or .Values.components.init_db.annotations .Values.annotations.pod }}
       annotations:
         {{- with .Values.annotations.pod }}{{ toYaml . | nindent 8 }}{{- end }}
-        {{- with .Values.components.api.annotations }}{{ toYaml . | nindent 8 }}{{- end }}
+        {{- with .Values.components.init_db.annotations }}{{ toYaml . | nindent 8 }}{{- end }}
       {{- end }}
     spec:
       {{- if .Values.imagePullSecrets.enabled }}

--- a/charts/kasm/values.schema.json
+++ b/charts/kasm/values.schema.json
@@ -237,6 +237,30 @@
             "labels"
           ]
         },
+        "init_db": {
+          "additionalProperties": false,
+          "description": "Configuration settings for the DB initialization job",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Custom annotations to add to the DB init Job. By default includes helm.sh/hook for Helm deployments. ArgoCD users should override this to remove the hook to prevent deployment deadlocks.",
+              "title": "annotations",
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": "Custom labels to add to the DB init Job",
+              "title": "labels",
+              "type": "object"
+            }
+          },
+          "title": "init_db",
+          "type": "object",
+          "requied": [
+            "annotations",
+            "labels"
+          ]
+        },
         "guac": {
           "additionalProperties": false,
           "description": " ",

--- a/charts/kasm/values.yaml
+++ b/charts/kasm/values.yaml
@@ -285,6 +285,16 @@ components:
     resources: {}
     # components.api.labels -- Custom labels to add to the Kasm api Deployment
     labels: {}
+  # Configuration settings for the DB initialization job
+  #
+  init_db:
+    # components.init_db.annotations -- Custom annotations to add to the DB init Job.
+    # By default includes helm.sh/hook for Helm deployments. ArgoCD users should override
+    # this to remove the hook to prevent deployment deadlocks.
+    annotations:
+      helm.sh/hook: pre-install
+    # components.init_db.labels -- Custom labels to add to the DB init Job
+    labels: {}
   # Configuration settings for the Kasm Manager service
   #
   manager:


### PR DESCRIPTION
Created dedicated `components.init_db.annotations` configuration separate from `components.api.annotations`.

The db-init-job template now uses this dedicated variable instead of sharing the API annotations.

Default value includes `helm.sh/hook: pre-install` for Helm deployments, but **ArgoCD** users can override this to remove the hook and prevent deployment deadlocks.

Changes:
- Added `components.init_db.annotations` and `components.init_db.labels` to `values.yaml`
- Updated `db-init-job` template to use `init_db` instead of `api` variables
- Documented ArgoCD override requirement in values comments

This prevents the deadlock where:
1. ArgoCD adds hook-finalizer when it sees helm.sh/hook annotation
2. ArgoCD waits for `db-init-job` hook before deploying wave 3
3. `db-init-job` waits for PostgreSQL (wave 3)
4. Result: infinite wait