### PR TITLE
Initcontainers, extra env and extra volumes

### DIFF
--- a/charts/kasm/Chart.yaml
+++ b/charts/kasm/Chart.yaml
@@ -28,4 +28,4 @@ keywords:
 maintainers:
   - name: Kasm Technologies, Inc.
     url: https://github.com/kasmtech/kasm-helm
-version: 1.1181.0
+version: 1.1181.1

--- a/charts/kasm/templates/api-deployment.yaml
+++ b/charts/kasm/templates/api-deployment.yaml
@@ -123,7 +123,7 @@ spec:
                   key: "db-password"
                 {{- end }}
             {{- if .Values.components.api.extraEnv }}
-              {{- toYaml .Values.components.api.extraEnv | nindent 10 }}
+              {{- toYaml .Values.components.api.extraEnv | nindent 12 }}
             {{- end }}
           ports:
             - name: {{ $constants.api.portName }}

--- a/charts/kasm/templates/api-deployment.yaml
+++ b/charts/kasm/templates/api-deployment.yaml
@@ -122,6 +122,9 @@ spec:
                   name: {{ .Release.Name }}-secrets
                   key: "db-password"
                 {{- end }}
+            {{- if .Values.components.api.extraEnv }}
+              {{- toYaml .Values.components.api.extraEnv | nindent 10 }}
+            {{- end }}
           ports:
             - name: {{ $constants.api.portName }}
               containerPort: {{ $constants.api.port }}

--- a/charts/kasm/templates/api-deployment.yaml
+++ b/charts/kasm/templates/api-deployment.yaml
@@ -59,6 +59,9 @@ spec:
       {{- with .Values.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.components.api.extraVolumes }}
+      volumes: {{ toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: db-is-ready
           image: {{ $constants.api.image }}
@@ -90,6 +93,9 @@ spec:
           {{- if .Values.applySecurity }}
             {{- include "kasm.containerSecurity" . | indent 10 }}
           {{- end }}
+        {{- if .Values.components.api.initContainers }}
+          {{- toYaml .Values.components.api.initContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ $constants.api.name }}-container
           image: {{ $constants.api.image }}
@@ -133,4 +139,7 @@ spec:
           {{- end }}
           {{- if .Values.applyPodSecurity }}
             {{- include "kasm.containerSecurity" . | indent 10 }}
+          {{- end }}
+          {{- with .Values.components.api.extraVolumeMounts }}
+          volumeMounts: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/kasm/templates/guac-deployment.yaml
+++ b/charts/kasm/templates/guac-deployment.yaml
@@ -81,6 +81,9 @@ spec:
         {{- if .Values.applySecurity }}
           {{- include "kasm.containerSecurity" . | indent 10 }}
         {{- end }}
+        {{- if .Values.components.guac.initContainers }}
+          {{- toYaml .Values.components.guac.initContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ $constants.guac.name }}-container
           image: {{ $constants.guac.image }}
@@ -111,8 +114,9 @@ spec:
             - name: {{ $constants.guac.portName }}
               containerPort: {{ $constants.guac.port }}
               protocol: TCP
-          {{- if .Values.applySecurity }}
+          {{- if or .Values.applySecurity .Values.components.guac.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.applySecurity }}
             - name: {{ $constants.guac.name }}-data
               mountPath: /tmp
             - name: {{ $constants.guac.name }}-readonly
@@ -120,6 +124,10 @@ spec:
               readOnly: true
             - name: {{ $constants.guac.name }}-data
               mountPath: /opt/kasm/current/tmp/guac
+            {{- end }}
+            {{- if .Values.components.guac.extraVolumeMounts }}
+              {{- toYaml .Values.components.guac.extraVolumeMounts | nindent 10 }}
+            {{- end }}
           {{- end }}
           {{- if .Values.applyHealthChecks }}
           livenessProbe:
@@ -137,13 +145,18 @@ spec:
           {{- if .Values.applySecurity }}
             {{- include "kasm.containerSecurity" . | indent 10 }}
           {{- end }}
-      {{- if .Values.applySecurity }}
+      {{- if or .Values.applySecurity .Values.components.guac.extraVolumes }}
       volumes:
+        {{- if .Values.applySecurity }}
         - name: {{ $constants.guac.name }}-data
           emptyDir:
             sizeLimit: 1Gi
         - name: {{ $constants.guac.name }}-readonly
           emptyDir:
             sizeLimit: 150Mi
+        {{- end }}
+        {{- if .Values.components.guac.extraVolumes }}
+          {{- toYaml .Values.components.guac.extraVolumes | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kasm/templates/guac-deployment.yaml
+++ b/charts/kasm/templates/guac-deployment.yaml
@@ -111,7 +111,7 @@ spec:
             - name: SERVER_PORT
               value: {{ $constants.guac.port | quote }}
             {{- if .Values.components.guac.extraEnv }}
-              {{- toYaml .Values.components.guac.extraEnv | nindent 10 }}
+              {{- toYaml .Values.components.guac.extraEnv | nindent 12 }}
             {{- end }}
           ports:
             - name: {{ $constants.guac.portName }}
@@ -129,7 +129,7 @@ spec:
               mountPath: /opt/kasm/current/tmp/guac
             {{- end }}
             {{- if .Values.components.guac.extraVolumeMounts }}
-              {{- toYaml .Values.components.guac.extraVolumeMounts | nindent 10 }}
+              {{- toYaml .Values.components.guac.extraVolumeMounts | nindent 12 }}
             {{- end }}
           {{- end }}
           {{- if .Values.applyHealthChecks }}

--- a/charts/kasm/templates/guac-deployment.yaml
+++ b/charts/kasm/templates/guac-deployment.yaml
@@ -110,6 +110,9 @@ spec:
               value: {{ $constants.guac.svc }}
             - name: SERVER_PORT
               value: {{ $constants.guac.port | quote }}
+            {{- if .Values.components.guac.extraEnv }}
+              {{- toYaml .Values.components.guac.extraEnv | nindent 10 }}
+            {{- end }}
           ports:
             - name: {{ $constants.guac.portName }}
               containerPort: {{ $constants.guac.port }}

--- a/charts/kasm/templates/manager-deployment.yaml
+++ b/charts/kasm/templates/manager-deployment.yaml
@@ -97,6 +97,9 @@ spec:
                   name: {{ $.Release.Name }}-secrets
                   key: "db-password"
                 {{- end }}
+            {{- if $values.components.manager.extraEnv }}
+              {{- toYaml $values.components.manager.extraEnv | nindent 10 }}
+            {{- end }}
           ports:
             - name: {{ printf "zn%s-%s" ($idx | toString) $constants.manager.portName }}
               containerPort: {{ $constants.manager.port }}

--- a/charts/kasm/templates/manager-deployment.yaml
+++ b/charts/kasm/templates/manager-deployment.yaml
@@ -63,7 +63,11 @@ spec:
       {{- with $values.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
-      initContainers: {{- include "kasm.initContainer" (dict "serviceName" $constants.api.svc "servicePort" $constants.api.port "path" "/api/__healthcheck" "schema" "http" "image" $constants.api.image) | indent 8 }}
+      initContainers:
+        {{- include "kasm.initContainer" (dict "serviceName" $constants.api.svc "servicePort" $constants.api.port "path" "/api/__healthcheck" "schema" "http" "image" $constants.api.image) | indent 8 }}
+        {{- if $values.components.manager.initContainers }}
+          {{- toYaml $values.components.manager.initContainers | nindent 8 }}
+        {{- end }}
       {{- if $values.applySecurity }}
         {{- include "kasm.containerSecurity" . | indent 10 }}
       {{- end }}
@@ -116,8 +120,14 @@ spec:
           volumeMounts:
             - name: {{ $constants.manager.name }}-tmp
               mountPath: /tmp
+            {{- if $values.components.manager.extraVolumeMounts }}
+              {{- toYaml $values.components.manager.extraVolumeMounts | nindent 10 }}
+            {{- end }}
       volumes:
         - name: {{ $constants.manager.name }}-tmp
           emptyDir:
             sizeLimit: 1Gi
+        {{- if $values.components.manager.extraVolumes }}
+          {{- toYaml $values.components.manager.extraVolumes | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/charts/kasm/templates/manager-deployment.yaml
+++ b/charts/kasm/templates/manager-deployment.yaml
@@ -98,7 +98,7 @@ spec:
                   key: "db-password"
                 {{- end }}
             {{- if $values.components.manager.extraEnv }}
-              {{- toYaml $values.components.manager.extraEnv | nindent 10 }}
+              {{- toYaml $values.components.manager.extraEnv | nindent 12 }}
             {{- end }}
           ports:
             - name: {{ printf "zn%s-%s" ($idx | toString) $constants.manager.portName }}
@@ -124,7 +124,7 @@ spec:
             - name: {{ $constants.manager.name }}-tmp
               mountPath: /tmp
             {{- if $values.components.manager.extraVolumeMounts }}
-              {{- toYaml $values.components.manager.extraVolumeMounts | nindent 10 }}
+              {{- toYaml $values.components.manager.extraVolumeMounts | nindent 12 }}
             {{- end }}
       volumes:
         - name: {{ $constants.manager.name }}-tmp

--- a/charts/kasm/templates/proxy-deployment.yaml
+++ b/charts/kasm/templates/proxy-deployment.yaml
@@ -124,6 +124,9 @@ spec:
           {{- if $values.applySecurity }}
             {{- include "kasm.containerSecurity" . | indent 10 }}
           {{- end }}
+          {{- with $values.components.proxy.env }}
+          env: {{ toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: {{ $constants.proxy.name }}-cert
               mountPath: /etc/ssl/certs/kasm_nginx.crt

--- a/charts/kasm/templates/proxy-deployment.yaml
+++ b/charts/kasm/templates/proxy-deployment.yaml
@@ -109,6 +109,9 @@ spec:
             {{- include "kasm.containerSecurity" . | indent 10 }}
           {{- end }}
         {{- end }}
+        {{- if $values.components.proxy.initContainers }}
+          {{- toYaml $values.components.proxy.initContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ $constants.proxy.name }}-container
           image: {{ $constants.proxy.image }}
@@ -135,6 +138,9 @@ spec:
             - name: {{ $constants.proxy.name }}-base-config
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
+            {{- if $values.components.proxy.extraVolumeMounts }}
+              {{- toYaml $values.components.proxy.extraVolumeMounts | nindent 10 }}
+            {{- end }}
             {{- if $values.applySecurity }}
             - name: {{ $constants.proxy.name }}-data
               mountPath: /var/cache/nginx
@@ -171,6 +177,9 @@ spec:
         - name: {{ $constants.proxy.name }}-services-config
           configMap:
             name: {{ $constants.proxy.name }}-services-configmap
+        {{- if $values.components.proxy.extraVolumes }}
+          {{- toYaml $values.components.proxy.extraVolumes | nindent 8 }}
+        {{- end }}
         {{- if $values.applySecurity }}
         - name: {{ $constants.proxy.name }}-data
           emptyDir:

--- a/charts/kasm/templates/proxy-deployment.yaml
+++ b/charts/kasm/templates/proxy-deployment.yaml
@@ -124,7 +124,7 @@ spec:
           {{- if $values.applySecurity }}
             {{- include "kasm.containerSecurity" . | indent 10 }}
           {{- end }}
-          {{- with $values.components.proxy.env }}
+          {{- with $values.components.proxy.extraEnv }}
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
@@ -142,7 +142,7 @@ spec:
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
             {{- if $values.components.proxy.extraVolumeMounts }}
-              {{- toYaml $values.components.proxy.extraVolumeMounts | nindent 10 }}
+              {{- toYaml $values.components.proxy.extraVolumeMounts | nindent 12 }}
             {{- end }}
             {{- if $values.applySecurity }}
             - name: {{ $constants.proxy.name }}-data

--- a/charts/kasm/templates/rdp-gateway-deployment.yaml
+++ b/charts/kasm/templates/rdp-gateway-deployment.yaml
@@ -85,6 +85,9 @@ spec:
         {{- if .Values.applySecurity }}
           {{- include "kasm.containerSecurity" . | indent 10 }}
         {{- end }}
+        {{- if .Values.components.rdpGateway.initContainers }}
+          {{- toYaml .Values.components.rdpGateway.initContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ $constants.rdpGateway.name }}-container
           image: {{ $constants.rdpGateway.image }}
@@ -141,6 +144,9 @@ spec:
             - name: {{ $constants.rdpGateway.name }}-config
               mountPath: /usr/local/etc/rdpproxy/conf/passthrough.app.config.yaml
               subPath: passthrough.app.config.yaml
+            {{- if .Values.components.rdpGateway.extraVolumeMounts }}
+              {{- toYaml .Values.components.rdpGateway.extraVolumeMounts | nindent 10 }}
+            {{- end }}
       volumes:
         - name: {{ $constants.rdpGateway.name }}-cert
           secret:
@@ -151,4 +157,7 @@ spec:
         - name: {{ $constants.rdpGateway.name }}-config
           configMap:
             name: {{ $constants.rdpGateway.name }}-configmap
+        {{- if .Values.components.rdpGateway.extraVolumes }}
+          {{- toYaml .Values.components.rdpGateway.extraVolumes | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/charts/kasm/templates/rdp-gateway-deployment.yaml
+++ b/charts/kasm/templates/rdp-gateway-deployment.yaml
@@ -109,7 +109,7 @@ spec:
             - name: KUBERNETES_SERVICE_HOST
               value: "true"
             {{- if .Values.components.rdpGateway.extraEnv }}
-              {{- toYaml .Values.components.rdpGateway.extraEnv | nindent 10 }}
+              {{- toYaml .Values.components.rdpGateway.extraEnv | nindent 12 }}
             {{- end }}
           ports:
             - name: {{ $constants.rdpGateway.portName }}
@@ -148,7 +148,7 @@ spec:
               mountPath: /usr/local/etc/rdpproxy/conf/passthrough.app.config.yaml
               subPath: passthrough.app.config.yaml
             {{- if .Values.components.rdpGateway.extraVolumeMounts }}
-              {{- toYaml .Values.components.rdpGateway.extraVolumeMounts | nindent 10 }}
+              {{- toYaml .Values.components.rdpGateway.extraVolumeMounts | nindent 12 }}
             {{- end }}
       volumes:
         - name: {{ $constants.rdpGateway.name }}-cert

--- a/charts/kasm/templates/rdp-gateway-deployment.yaml
+++ b/charts/kasm/templates/rdp-gateway-deployment.yaml
@@ -108,6 +108,9 @@ spec:
                   key: service-token
             - name: KUBERNETES_SERVICE_HOST
               value: "true"
+            {{- if .Values.components.rdpGateway.extraEnv }}
+              {{- toYaml .Values.components.rdpGateway.extraEnv | nindent 10 }}
+            {{- end }}
           ports:
             - name: {{ $constants.rdpGateway.portName }}
               containerPort: 5555

--- a/charts/kasm/templates/rdp-https-gateway-deployment.yaml
+++ b/charts/kasm/templates/rdp-https-gateway-deployment.yaml
@@ -105,7 +105,7 @@ spec:
             - name: KUBERNETES_SERVICE_HOST
               value: "true"
             {{- if .Values.components.rdpHttpsGateway.extraEnv }}
-              {{- toYaml .Values.components.rdpHttpsGateway.extraEnv | nindent 10 }}
+              {{- toYaml .Values.components.rdpHttpsGateway.extraEnv | nindent 12 }}
             {{- end }}
           ports:
             - name: {{ $constants.rdpHttpsGateway.portName }}
@@ -139,7 +139,7 @@ spec:
             - name: {{ $constants.rdpHttpsGateway.name }}-data
               mountPath: /tmp
             {{- if .Values.components.rdpHttpsGateway.extraVolumeMounts }}
-              {{- toYaml .Values.components.rdpHttpsGateway.extraVolumeMounts | nindent 10 }}
+              {{- toYaml .Values.components.rdpHttpsGateway.extraVolumeMounts | nindent 12 }}
             {{- end }}
       volumes:
         - name: {{ $constants.rdpHttpsGateway.name }}-cert

--- a/charts/kasm/templates/rdp-https-gateway-deployment.yaml
+++ b/charts/kasm/templates/rdp-https-gateway-deployment.yaml
@@ -104,6 +104,9 @@ spec:
                   key: service-token
             - name: KUBERNETES_SERVICE_HOST
               value: "true"
+            {{- if .Values.components.rdpHttpsGateway.extraEnv }}
+              {{- toYaml .Values.components.rdpHttpsGateway.extraEnv | nindent 10 }}
+            {{- end }}
           ports:
             - name: {{ $constants.rdpHttpsGateway.portName }}
               containerPort: {{ $constants.rdpHttpsGateway.port }}

--- a/charts/kasm/templates/rdp-https-gateway-deployment.yaml
+++ b/charts/kasm/templates/rdp-https-gateway-deployment.yaml
@@ -81,6 +81,9 @@ spec:
             - name: {{ $constants.rdpHttpsGateway.name }}-data
               mountPath: /tmp
         {{- end }}
+        {{- if .Values.components.rdpHttpsGateway.initContainers }}
+          {{- toYaml .Values.components.rdpHttpsGateway.initContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ $constants.rdpHttpsGateway.name }}-container
           image: {{ $constants.rdpHttpsGateway.image }}
@@ -132,6 +135,9 @@ spec:
               mountPath: /opt/kasm/current/log
             - name: {{ $constants.rdpHttpsGateway.name }}-data
               mountPath: /tmp
+            {{- if .Values.components.rdpHttpsGateway.extraVolumeMounts }}
+              {{- toYaml .Values.components.rdpHttpsGateway.extraVolumeMounts | nindent 10 }}
+            {{- end }}
       volumes:
         - name: {{ $constants.rdpHttpsGateway.name }}-cert
           secret:
@@ -139,4 +145,7 @@ spec:
         - name: {{ $constants.rdpHttpsGateway.name }}-data
           emptyDir:
             sizeLimit: 150Mi
+        {{- if .Values.components.rdpHttpsGateway.extraVolumes }}
+          {{- toYaml .Values.components.rdpHttpsGateway.extraVolumes | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/charts/kasm/values.schema.json
+++ b/charts/kasm/values.schema.json
@@ -161,17 +161,12 @@
           "description": "Set the secret name where the certificate is stored. This secret name will store a certificate created by `cert-manager` if you set `cert-manager.enabled` to true",
           "title": "secretName",
           "type": "string",
-          "required": [
-            "secretName"
-          ]
+          "required": ["secretName"]
         }
       },
       "title": "certificate",
       "type": "object",
-      "required": [
-        "secretName",
-        "certManager"
-      ]
+      "required": ["secretName", "certManager"]
     },
     "clusterDomain": {
       "default": "cluster.local",
@@ -192,6 +187,24 @@
               "title": "annotations",
               "type": "object"
             },
+            "extraVolumes": {
+              "additionalProperties": true,
+              "description": "Additional volumes to add to pod",
+              "title": "extraVolumes",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "extraVolumeMounts": {
+              "additionalProperties": true,
+              "description": "Additional volumes to mount",
+              "title": "extraVolumeMounts",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
             "image": {
               "additionalProperties": false,
               "description": "Configure the image repository where the image is stored. Use this to point to an private hosted container registry instead of our public DockerHub hosted one.",
@@ -209,10 +222,16 @@
               },
               "title": "image",
               "type": "object",
-              "requied": [
-                "repository",
-                "tag"
-              ]
+              "requied": ["repository", "tag"]
+            },
+            "initContainers": {
+              "additionalProperties": true,
+              "description": "Custom init containers to run",
+              "title": "initContainers",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "labels": {
               "additionalProperties": true,
@@ -234,7 +253,10 @@
             "image",
             "resources",
             "annotations",
-            "labels"
+            "labels",
+            "initContainers",
+            "extraVolumes",
+            "extraVolumeMounts"
           ]
         },
         "guac": {
@@ -253,6 +275,24 @@
               "title": "enabled",
               "type": "boolean"
             },
+            "extraVolumes": {
+              "additionalProperties": true,
+              "description": "Additional volumes to add to pod",
+              "title": "extraVolumes",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "extraVolumeMounts": {
+              "additionalProperties": true,
+              "description": "Additional volumes to mount",
+              "title": "extraVolumeMounts",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
             "image": {
               "additionalProperties": false,
               "description": "Configure the image repository where the image is stored. Use this to point to an private hosted container registry instead of our public DockerHub hosted one.",
@@ -270,10 +310,16 @@
               },
               "title": "image",
               "type": "object",
-              "requied": [
-                "repository",
-                "tag"
-              ]
+              "requied": ["repository", "tag"]
+            },
+            "initContainers": {
+              "additionalProperties": true,
+              "description": "Custom init containers to run",
+              "title": "initContainers",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "labels": {
               "additionalProperties": true,
@@ -295,7 +341,10 @@
             "image",
             "resources",
             "annotations",
-            "labels"
+            "labels",
+            "initContainers",
+            "extraVolumes",
+            "extraVolumeMounts"
           ]
         },
         "manager": {
@@ -307,6 +356,24 @@
               "description": "Custom annotations to add to the Kasm Manager Deployment",
               "title": "annotations",
               "type": "object"
+            },
+            "extraVolumes": {
+              "additionalProperties": true,
+              "description": "Additional volumes to add to pod",
+              "title": "extraVolumes",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "extraVolumeMounts": {
+              "additionalProperties": true,
+              "description": "Additional volumes to mount",
+              "title": "extraVolumeMounts",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "image": {
               "additionalProperties": false,
@@ -325,10 +392,16 @@
               },
               "title": "image",
               "type": "object",
-              "requied": [
-                "repository",
-                "tag"
-              ]
+              "requied": ["repository", "tag"]
+            },
+            "initContainers": {
+              "additionalProperties": true,
+              "description": "Custom init containers to run",
+              "title": "initContainers",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "labels": {
               "additionalProperties": true,
@@ -350,7 +423,10 @@
             "image",
             "resources",
             "annotations",
-            "labels"
+            "labels",
+            "initContainers",
+            "extraVolumes",
+            "extraVolumeMounts"
           ]
         },
         "proxy": {
@@ -362,6 +438,24 @@
               "description": "Custom annotations to add to the Kasm Proxy Deployment",
               "title": "annotations",
               "type": "object"
+            },
+            "extraVolumes": {
+              "additionalProperties": true,
+              "description": "Additional volumes to add to pod",
+              "title": "extraVolumes",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "extraVolumeMounts": {
+              "additionalProperties": true,
+              "description": "Additional volumes to mount",
+              "title": "extraVolumeMounts",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "image": {
               "additionalProperties": false,
@@ -380,10 +474,16 @@
               },
               "title": "image",
               "type": "object",
-              "requied": [
-                "repository",
-                "tag"
-              ]
+              "requied": ["repository", "tag"]
+            },
+            "initContainers": {
+              "additionalProperties": true,
+              "description": "Custom init containers to run",
+              "title": "initContainers",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "labels": {
               "additionalProperties": true,
@@ -405,7 +505,10 @@
             "image",
             "resources",
             "annotations",
-            "labels"
+            "labels",
+            "initContainers",
+            "extraVolumes",
+            "extraVolumeMounts"
           ]
         },
         "rdpGateway": {
@@ -424,6 +527,24 @@
               "title": "enabled",
               "type": "boolean"
             },
+            "extraVolumes": {
+              "additionalProperties": true,
+              "description": "Additional volumes to add to pod",
+              "title": "extraVolumes",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "extraVolumeMounts": {
+              "additionalProperties": true,
+              "description": "Additional volumes to mount",
+              "title": "extraVolumeMounts",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
             "image": {
               "additionalProperties": false,
               "description": "Configure the image repository where the image is stored. Use this to point to an private hosted container registry instead of our public DockerHub hosted one.",
@@ -441,10 +562,16 @@
               },
               "title": "image",
               "type": "object",
-              "requied": [
-                "repository",
-                "tag"
-              ]
+              "requied": ["repository", "tag"]
+            },
+            "initContainers": {
+              "additionalProperties": true,
+              "description": "Custom init containers to run",
+              "title": "initContainers",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "labels": {
               "additionalProperties": true,
@@ -466,7 +593,10 @@
             "image",
             "resources",
             "annotations",
-            "labels"
+            "labels",
+            "initContainers",
+            "extraVolumes",
+            "extraVolumeMounts"
           ]
         },
         "rdpHttpsGateway": {
@@ -485,6 +615,24 @@
               "title": "enabled",
               "type": "boolean"
             },
+            "extraVolumes": {
+              "additionalProperties": true,
+              "description": "Additional volumes to add to pod",
+              "title": "extraVolumes",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "extraVolumeMounts": {
+              "additionalProperties": true,
+              "description": "Additional volumes to mount",
+              "title": "extraVolumeMounts",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
             "image": {
               "additionalProperties": false,
               "description": "Configure the image repository where the image is stored. Use this to point to an private hosted container registry instead of our public DockerHub hosted one.",
@@ -502,10 +650,16 @@
               },
               "title": "image",
               "type": "object",
-              "requied": [
-                "repository",
-                "tag"
-              ]
+              "requied": ["repository", "tag"]
+            },
+            "initContainers": {
+              "additionalProperties": true,
+              "description": "Custom init containers to run",
+              "title": "initContainers",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "labels": {
               "additionalProperties": true,
@@ -527,7 +681,10 @@
             "image",
             "resources",
             "annotations",
-            "labels"
+            "labels",
+            "initContainers",
+            "extraVolumes",
+            "extraVolumeMounts"
           ]
         }
       },
@@ -567,10 +724,7 @@
           },
           "title": "image",
           "type": "object",
-          "requied": [
-            "repository",
-            "tag"
-          ]
+          "requied": ["repository", "tag"]
         },
         "kasmDbName": {
           "default": "kasm",
@@ -676,10 +830,7 @@
                 }
               },
               "title": "retentionPolicy",
-              "required": [
-                "whenDeleted",
-                "whenScaled"
-              ]
+              "required": ["whenDeleted", "whenScaled"]
             },
             "storageClassName": {
               "default": "",
@@ -689,11 +840,7 @@
             }
           },
           "title": "storage",
-          "required": [
-            "storageClassName",
-            "pvcSize",
-            "retentionPolicy"
-          ]
+          "required": ["storageClassName", "pvcSize", "retentionPolicy"]
         }
       },
       "title": "database",
@@ -811,22 +958,14 @@
         }
       },
       "title": "dbManagement",
-      "required": [
-        "initialize",
-        "upgrade",
-        "backupCron"
-      ]
+      "required": ["initialize", "upgrade", "backupCron"]
     },
     "deploymentSize": {
       "default": "small",
       "description": "Define the estimated size of the Kasm deployment in expected session load.  small  = Up to 10-15 sessions  medium = Up to 25-30 sessions  large  = Up to 50+ sessions",
       "title": "deploymentSize",
       "type": "string",
-      "enum": [
-        "small",
-        "medium",
-        "large"
-      ]
+      "enum": ["small", "medium", "large"]
     },
     "extraLabels": {
       "additionalProperties": false,
@@ -1081,10 +1220,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "name",
-          "upstream_auth_addr"
-        ]
+        "required": ["name", "upstream_auth_addr"]
       }
     },
     "labels": {
@@ -1117,27 +1253,18 @@
           "default": "LoadBalancer",
           "title": "type",
           "type": "string",
-          "enum": [
-            "ClusterIP",
-            "LoadBalancer"
-          ]
+          "enum": ["ClusterIP", "LoadBalancer"]
         }
       },
       "title": "proxyService",
       "type": "object",
-      "required": [
-        "type",
-        "annotations",
-        "labels"
-      ]
+      "required": ["type", "annotations", "labels"]
     },
     "publicAddr": {
       "description": "Set the access URL to be used for the Kasm deployment. This is the URL you will use to access your Kasm deployment. This URL can be a private address, it just needs to be resolvable by systems you use to interface with Kasm.",
       "title": "publicAddr",
       "type": "string",
-      "required": [
-        "publicAddr"
-      ]
+      "required": ["publicAddr"]
     },
     "restartPolicy": {
       "default": "Always",
@@ -1196,12 +1323,7 @@
       },
       "title": "route",
       "type": "object",
-      "required": [
-        "enabled",
-        "tls",
-        "annotations",
-        "labels"
-      ]
+      "required": ["enabled", "tls", "annotations", "labels"]
     }
   },
   "type": "object"

--- a/charts/kasm/values.schema.json
+++ b/charts/kasm/values.schema.json
@@ -187,6 +187,15 @@
               "title": "annotations",
               "type": "object"
             },
+            "extraEnv": {
+              "additionalProperties": true,
+              "description": "Additional environement variables",
+              "title": "extraEnv",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
             "extraVolumes": {
               "additionalProperties": true,
               "description": "Additional volumes to add to pod",
@@ -255,6 +264,7 @@
             "annotations",
             "labels",
             "initContainers",
+            "extraEnv",
             "extraVolumes",
             "extraVolumeMounts"
           ]
@@ -274,6 +284,15 @@
               "description": "Use this setting to enable/disable deployment of the Kasm Guacamole web RDP service - [Kasm Guac Service](https://docs.kasm.com/docs/guide/connection_proxies#guacamole-guac).",
               "title": "enabled",
               "type": "boolean"
+            },
+            "extraEnv": {
+              "additionalProperties": true,
+              "description": "Additional environement variables",
+              "title": "extraEnv",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "extraVolumes": {
               "additionalProperties": true,
@@ -343,6 +362,7 @@
             "annotations",
             "labels",
             "initContainers",
+            "extraEnv",
             "extraVolumes",
             "extraVolumeMounts"
           ]
@@ -356,6 +376,15 @@
               "description": "Custom annotations to add to the Kasm Manager Deployment",
               "title": "annotations",
               "type": "object"
+            },
+            "extraEnv": {
+              "additionalProperties": true,
+              "description": "Additional environement variables",
+              "title": "extraEnv",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "extraVolumes": {
               "additionalProperties": true,
@@ -425,6 +454,7 @@
             "annotations",
             "labels",
             "initContainers",
+            "extraEnv",
             "extraVolumes",
             "extraVolumeMounts"
           ]
@@ -438,6 +468,15 @@
               "description": "Custom annotations to add to the Kasm Proxy Deployment",
               "title": "annotations",
               "type": "object"
+            },
+            "extraEnv": {
+              "additionalProperties": true,
+              "description": "Additional environement variables",
+              "title": "extraEnv",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "extraVolumes": {
               "additionalProperties": true,
@@ -507,6 +546,7 @@
             "annotations",
             "labels",
             "initContainers",
+            "extraEnv",
             "extraVolumes",
             "extraVolumeMounts"
           ]
@@ -526,6 +566,15 @@
               "description": "Use this setting to enable/disable deployment of the Kasm RDP Gateway service -  [Kasm RDP Gateway](https://docs.kasm.com/docs/guide/connection_proxies#rdp-gateway).",
               "title": "enabled",
               "type": "boolean"
+            },
+            "extraEnv": {
+              "additionalProperties": true,
+              "description": "Additional environement variables",
+              "title": "extraEnv",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "extraVolumes": {
               "additionalProperties": true,
@@ -595,6 +644,7 @@
             "annotations",
             "labels",
             "initContainers",
+            "extraEnv",
             "extraVolumes",
             "extraVolumeMounts"
           ]
@@ -614,6 +664,15 @@
               "description": "Use this setting to enable/disable deployment of the Kasm RDP HTTPS Gateway service. This service allows users to use native RDP clients via HTTPS connections rather than exposing 3389 - [Kasm RDP HTTPS Gateway](https://docs.kasm.com/docs/guide/connection_proxies#rdp-https-gateway).",
               "title": "enabled",
               "type": "boolean"
+            },
+            "extraEnv": {
+              "additionalProperties": true,
+              "description": "Additional environement variables",
+              "title": "extraEnv",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
             },
             "extraVolumes": {
               "additionalProperties": true,
@@ -683,6 +742,7 @@
             "annotations",
             "labels",
             "initContainers",
+            "extraEnv",
             "extraVolumes",
             "extraVolumeMounts"
           ]

--- a/charts/kasm/values.yaml
+++ b/charts/kasm/values.yaml
@@ -272,6 +272,8 @@ components:
     labels: {}
     # components.proxy.initContainers -- Custom init containers to run
     initContainers: []
+    # components.proxy.extraEnv -- Additional environment variables
+    extraEnv: []
     # components.proxy.extraVolumes -- Additional volumes to add to pod
     extraVolumes: []
     # components.proxy.extraVolumeMounts -- Additional volume mounts
@@ -293,6 +295,8 @@ components:
     labels: {}
     # components.api.initContainers -- Custom init containers to run
     initContainers: []
+    # components.api.extraEnv -- Additional environment variables
+    extraEnv: []
     # components.api.extraVolumes -- Additional volumes to add to pod
     extraVolumes: []
     # components.api.extraVolumeMounts -- Additional volume mounts
@@ -314,6 +318,8 @@ components:
     labels: {}
     # components.manager.initContainers -- Custom init containers to run
     initContainers: []
+    # components.manager.extraEnv -- Additional environment variables
+    extraEnv: []
     # components.manager.extraVolumes -- Additional volumes to add to pod
     extraVolumes: []
     # components.manager.extraVolumeMounts -- Additional volume mounts
@@ -339,6 +345,8 @@ components:
     labels: {}
     # components.guac.initContainers -- Custom init containers to run
     initContainers: []
+    # components.guac.extraEnv -- Additional environment variables
+    extraEnv: []
     # components.guac.extraVolumes -- Additional volumes to add to pod
     extraVolumes: []
     # components.guac.extraVolumeMounts -- Additional volume mounts
@@ -364,6 +372,8 @@ components:
     labels: {}
     # components.rdpGateway.initContainers -- Custom init containers to run
     initContainers: []
+    # components.rdpGateway.extraEnv -- Additional environment variables
+    extraEnv: []
     # components.rdpGateway.extraVolumes -- Additional volumes to add to pod
     extraVolumes: []
     # components.rdpGateway.extraVolumeMounts -- Additional volume mounts
@@ -390,6 +400,8 @@ components:
     labels: {}
     # components.rdpHttpsGateway.initContainers -- Custom init containers to run
     initContainers: []
+    # components.rdpHttpsGateway.extraEnv -- Additional environment variables
+    extraEnv: []
     # components.rdpHttpsGateway.extraVolumes -- Additional volumes to add to pod
     extraVolumes: []
     # components.rdpHttpsGateway.extraVolumeMounts -- Additional volume mounts

--- a/charts/kasm/values.yaml
+++ b/charts/kasm/values.yaml
@@ -9,7 +9,7 @@ deploymentSize: "small"
 # publicAddr -- Set the access URL to be used for the Kasm deployment. This is the URL you will use to access
 # your Kasm deployment. This URL can be a private address, it just needs to be resolvable by systems you use
 # to interface with Kasm.
-# 
+#
 # If you create a self-signed or custom certificate, this is the value you should assign as the Common Name
 # associated with the certificate. If `certificate.certManager.enabled` is set to true, this is the
 # name used to generate the certificate.
@@ -34,9 +34,9 @@ kasmZones: []
 #     upstream_auth_addr: zone-a.kasm.contoso.com
 #   - name: Zone-B
 #     upstream_auth_addr: zone-b.kasm.contoso.com
-    
-# proxyService -- Configure the external-facing service type to use. 
-# Allowed service types: ClusterIP or LoadBalancer. 
+
+# proxyService -- Configure the external-facing service type to use.
+# Allowed service types: ClusterIP or LoadBalancer.
 #
 # The service.annotations defined here only apply to the `proxy` service (`proxy-service-external.yaml` file).
 # If you wish to apply annotations to all services, use the annotations.service value at the bottom of this chart.
@@ -50,8 +50,8 @@ proxyService:
   annotations: {}
   labels: {}
 
-# Configure an Ingress for your Kasm deployment. 
-# 
+# Configure an Ingress for your Kasm deployment.
+#
 ingress:
   # ingress.enabled -- Set the enabled value to `true` to use a pre-defined Ingress service to expose Kasm
   #
@@ -72,12 +72,12 @@ ingress:
   annotations: {}
   labels: {}
 
-# route -- Configure an OpenShift Route for your Kasm deployment. 
-# 
+# route -- Configure an OpenShift Route for your Kasm deployment.
+#
 route:
   # route.enabled -- Set the enabled value to `true` to use a pre-defined Route service to expose Kasm
   enabled: false
-  # route.tls -- Object to define the TLS configuration for your OpenShift Route - 
+  # route.tls -- Object to define the TLS configuration for your OpenShift Route -
   # [Configuring Secure Routes](https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/networking/configuring-routes#configuring-default-certificate).
   #
   tls: {}
@@ -111,12 +111,12 @@ certificate:
   #
   secretName: ""
   # certificate.certManager -- For additional cert-manager configuration/deployment information refer to the online documentation
-  # [Cert Manager Docs](https://cert-manager.io/v1.1-docs/installation/kubernetes/). 
-  # 
+  # [Cert Manager Docs](https://cert-manager.io/v1.1-docs/installation/kubernetes/).
+  #
   # NOTE: If you do not enable `cert-manager`, you must generate your own certificates and add them as a Kubernetes secret, or
   # present cloud-managed certificates.
   #
-  # Refer to [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/), and 
+  # Refer to [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/), and
   # [Kubernetes TLS Secret](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_tls/)
   # for more information.
   #
@@ -270,6 +270,12 @@ components:
     resources: {}
     # components.proxy.labels -- Custom labels to add to the Kasm Proxy Deployment
     labels: {}
+    # components.proxy.initContainers -- Custom init containers to run
+    initContainers: []
+    # components.proxy.extraVolumes -- Additional volumes to add to pod
+    extraVolumes: []
+    # components.proxy.extraVolumeMounts -- Additional volume mounts
+    extraVolumeMounts: []
   # Configuration settings for the Kasm API service
   #
   api:
@@ -285,6 +291,12 @@ components:
     resources: {}
     # components.api.labels -- Custom labels to add to the Kasm api Deployment
     labels: {}
+    # components.api.initContainers -- Custom init containers to run
+    initContainers: []
+    # components.api.extraVolumes -- Additional volumes to add to pod
+    extraVolumes: []
+    # components.api.extraVolumeMounts -- Additional volume mounts
+    extraVolumeMounts: []
   # Configuration settings for the Kasm Manager service
   #
   manager:
@@ -300,6 +312,12 @@ components:
     resources: {}
     # components.manager.labels -- Custom labels to add to the Kasm Manager Deployment
     labels: {}
+    # components.manager.initContainers -- Custom init containers to run
+    initContainers: []
+    # components.manager.extraVolumes -- Additional volumes to add to pod
+    extraVolumes: []
+    # components.manager.extraVolumeMounts -- Additional volume mounts
+    extraVolumeMounts: []
   # Configuration settings for the Kasm Guac RDP service
   #
   guac:
@@ -309,7 +327,7 @@ components:
     image:
       repository: kasmweb/kasm-guac
       tag: 1.18.1
-    # components.guac.enabled -- Use this setting to enable/disable deployment of the Kasm Guacamole web RDP service - 
+    # components.guac.enabled -- Use this setting to enable/disable deployment of the Kasm Guacamole web RDP service -
     # [Kasm Guac Service](https://docs.kasm.com/docs/guide/connection_proxies#guacamole-guac).
     #
     enabled: true
@@ -319,6 +337,12 @@ components:
     resources: {}
     # components.guac.labels -- Custom labels to add to the Kasm Guac Deployment
     labels: {}
+    # components.guac.initContainers -- Custom init containers to run
+    initContainers: []
+    # components.guac.extraVolumes -- Additional volumes to add to pod
+    extraVolumes: []
+    # components.guac.extraVolumeMounts -- Additional volume mounts
+    extraVolumeMounts: []
   # Configuration settings for the Kasm RDP Gateway service
   #
   rdpGateway:
@@ -328,7 +352,7 @@ components:
     image:
       repository: kasmweb/rdp-gateway
       tag: 1.18.1
-    # components.rdpGateway.enabled -- Use this setting to enable/disable deployment of the Kasm RDP Gateway service - 
+    # components.rdpGateway.enabled -- Use this setting to enable/disable deployment of the Kasm RDP Gateway service -
     # [Kasm RDP Gateway](https://docs.kasm.com/docs/guide/connection_proxies#rdp-gateway).
     #
     enabled: true
@@ -338,6 +362,12 @@ components:
     resources: {}
     # components.rdpGateway.labels -- Custom labels to add to the Kasm RDP Gateway Deployment
     labels: {}
+    # components.rdpGateway.initContainers -- Custom init containers to run
+    initContainers: []
+    # components.rdpGateway.extraVolumes -- Additional volumes to add to pod
+    extraVolumes: []
+    # components.rdpGateway.extraVolumeMounts -- Additional volume mounts
+    extraVolumeMounts: []
   # Configuration settings for the Kasm RDP HTTPS Gateway service
   #
   rdpHttpsGateway:
@@ -348,7 +378,7 @@ components:
       repository: kasmweb/rdp-https-gateway
       tag: 1.18.1
     # components.rdpHttpsGateway.enabled -- Use this setting to enable/disable deployment of the Kasm RDP HTTPS Gateway service.
-    # This service allows users to use native RDP clients via HTTPS connections rather than exposing 3389 - 
+    # This service allows users to use native RDP clients via HTTPS connections rather than exposing 3389 -
     # [Kasm RDP HTTPS Gateway](https://docs.kasm.com/docs/guide/connection_proxies#rdp-https-gateway.
     #
     enabled: true
@@ -358,6 +388,12 @@ components:
     resources: {}
     # components.rdpHttpsGateway.labels -- Custom labels to add to the Kasm RDP HTTPS Gateway Deployment
     labels: {}
+    # components.rdpHttpsGateway.initContainers -- Custom init containers to run
+    initContainers: []
+    # components.rdpHttpsGateway.extraVolumes -- Additional volumes to add to pod
+    extraVolumes: []
+    # components.rdpHttpsGateway.extraVolumeMounts -- Additional volume mounts
+    extraVolumeMounts: []
 
 ####################################
 # Extra Kubernetes config settings #
@@ -397,12 +433,12 @@ imagePullSecrets:
 #
 clusterDomain: "cluster.local"
 
-# nodeSelector -- Configure node selector settings for your Kasm pods - 
+# nodeSelector -- Configure node selector settings for your Kasm pods -
 # [Kubernetes Node Selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
 #
 nodeSelector: {}
 
-# affinity -- Configure node affinity settings for Kasm pods - 
+# affinity -- Configure node affinity settings for Kasm pods -
 # [Kubernetes Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
 # Kasm is not guaranteed to work with Affinity settings - use caution if you must configuring these settings.
 # The below, optional object passes in raw Affinity rules for Pods, Nodes, etc. for your environment. Make sure you


### PR DESCRIPTION
This PR adds the ability to specify custom init containers, extra volumes and volume mounts, and extra environment variables for each of the components (api, proxy, guac, etc.).

This works alongside existing init containers and volume mounts.

This helps if, for example, you need to mount a custom root ca and apply it by running update-ca-certificates.